### PR TITLE
forcing https won't work in localhost

### DIFF
--- a/templates/tictactoe.html
+++ b/templates/tictactoe.html
@@ -43,7 +43,7 @@
       </div>
       <script type="text/javascript">
         function init() {
-          google.devrel.samples.ttt.init('https://' + window.location.host + '/_ah/api');
+          google.devrel.samples.ttt.init('http://' + window.location.host + '/_ah/api');
         }
       </script>
       <script src="https://apis.google.com/js/client.js?onload=init"></script>


### PR DESCRIPTION
It's fine once the app is deployed, but in localhost we get a SSL connection error when trying to access the following resource: https://localhost:NNNNN/_ah/api/static/proxy.html?...
