### PR TITLE
Unnecesary call to gapi.auth.getToken()?

### DIFF
--- a/static/js/base.js
+++ b/static/js/base.js
@@ -90,10 +90,9 @@ google.devrel.samples.ttt.waitingForMove = true;
 /**
  * Loads the application UI after the user has completed auth.
  */
-google.devrel.samples.ttt.userAuthed = function() {
+google.devrel.samples.ttt.userAuthed = function(token) {
   var request = gapi.client.oauth2.userinfo.get().execute(function(resp) {
     if (!resp.code) {
-      var token = gapi.auth.getToken();
       // Use id_token instead of bearer token
       token.access_token = token.id_token;
       gapi.auth.setToken(token);


### PR DESCRIPTION
According to the [docs](https://developers.google.com/api-client-library/javascript/reference/referencedocs#gapiauthauthorize) the callback in gapi.auth.authorize() already receives the OAuth 2.0 token as its parameter.
